### PR TITLE
Improve results indexing in experiments

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -52,8 +52,8 @@ def main():
     results = {name: [] for name in pipelines}
     index = []
 
-    for dataset in datasets:
-        index.append(dataset)
+    for idx, dataset in enumerate(datasets, start=1):
+        index.append(f"DS-{idx}")
         f1_scores = {name: [] for name in pipelines}
         for (x_train, y_train, x_test, y_test), params in zip(
             kd.load_data(dataset), preset_params[dataset]


### PR DESCRIPTION
## Summary
- index experiment results by dataset number (DS-1, DS-2, ...)

## Testing
- `python - <<'PY'
import keel_ds as kd
print(len(kd.list_data('balanced')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687ee54cbf4c832ebb7ddf535fd12bab