### PR TITLE
Add multiprocessing support with progress bars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ rich==13.8.0
 scikit_learn==1.5.1
 scipy==1.14.1
 skrebate==0.62
+tqdm==4.66.4


### PR DESCRIPTION
## Summary
- allow specifying worker processes in `run_experiments.py`
- display dataset and pipeline progress using `tqdm`
- run pipelines concurrently with `ProcessPoolExecutor`
- document new dependency

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`
- `python -m py_compile run_experiments.py`
- `python run_experiments.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_687f802b6c00832eb1a1e79c8428ee59